### PR TITLE
Update bfield::create() to use full path not just filename

### DIFF
--- a/src/bfield.rs
+++ b/src/bfield.rs
@@ -32,10 +32,10 @@ impl<'a, T: Clone + DeserializeOwned + Serialize> BField<T> {
         let mut members = Vec::new();
         for n in 0..n_secondaries {
             // panics if filename == ''
-            let file = Path::with_extension(
+            let file = filename.as_ref().with_file_name(Path::with_extension(
                 Path::file_stem(filename.as_ref()).unwrap().as_ref(),
                 format!("{}.bfd", n),
-            );
+            ));
             let params = if n == 0 {
                 Some(other_params.clone())
             } else {


### PR DESCRIPTION
This PR makes a small change to the behavior of `create()` so that it uses a full filepath when creating the bfields and not just the filename. This allows us to run `mgo_build` from any directory. Prior to this change, you must `cd` into the directory the bfields were being created in otherwise a "missing bfield" exception would get thrown.