### PR TITLE
Update cargo docs, update crate to version 0.3.0 for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.60.0
+          toolchain: stable
           override: true
 
       - name: version info
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 .DS_Store
 .idea/
 old/
+docs/notebook/.python-version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [dependencies]
 bincode = "1"
-mmap-bitvec = "0.4.0"
+mmap-bitvec = "0.4.1"
 murmurhash3 = "0.0.5"
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,20 @@
 [package]
 name = "bfield"
-version = "0.2.1"
-authors = ["Roderick Bovee <roderick@onecodex.com>"]
+description = "B-field datastructure implementation in Rust"
+version = "0.3.0"
+authors = ["Vincent Prouillet <vincent@onecodex.com>", "Gerrit Gerritsen <gerrit@onecodex.com>", "Nick Greenfield <nick@onecodex.com>"]
+homepage = "https://github.com/onecodex/rust-bfield/"
+repository = "https://github.com/onecodex/rust-bfield/"
+readme = "README.md"
+keywords = ["B-field", "probabilistic data structures"]
+categories = ["data-structures"]
 edition = "2018"
+license = "Apache 2.0"
+exclude = [
+    ".gitignore",
+    ".github/*",
+    "docs/*",
+]
 
 [dependencies]
 bincode = "1"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # `rust-bfield`, an implementation of the B-field probabilistic key-value data structure
 
+[![Crates.io Version](https://img.shields.io/crates/v/bfield.svg)](https://crates.io/crates/bfield)
+
 The B-field is a novel, probabilistic data structure for storing key-value pairs (or, said differently, it is a probabilistic associative array or map). B-fields support insertion (`insert`) and lookup (`get`) operations, and share a number of mathematical and performance properties with the well-known [Bloom filter](https://doi.org/10.1145/362686.362692).
 
 At [One Codex](https://www.onecodex.com), we use the `rust-bfield` crate in bioinformatics applications to efficiently store associations between billions of $k$-length nucleotide substrings (["k-mers"](https://en.wikipedia.org/wiki/K-mer)) and [their taxonomic identity](https://www.ncbi.nlm.nih.gov/taxonomy) _**using only 6-7 bytes per `(kmer, value)` pair**_ for up to 100,000 unique taxonomic IDs (distinct values) and a 0.1% error rate. We hope others are able to use this library (or implementations in other languages) for applications in bioinformatics and beyond.
 
-> _Note: In the [Implementation Details](#implementation-details) section below, we detail the use of this B-field implementation in Rust and use `code` formatting and English parameter names (e.g., we discuss the B-field being a data structure for storing `(key, value)` pairs). In the following [Formal Data Structure Details](#formal-data-structure-details) section, we detail the design and mechanics of the B-field using mathematical notation (i.e., we discuss it as an associate array mapping a set of_ $(x, y)$ _pairs). The generated Rust documentation includes both notations for ease of reference._
+> _Note: In the [Implementation Details](#implementation-details) section below, we detail the use of this B-field implementation in Rust and use `code` formatting and English parameter names (e.g., we discuss the B-field being a data structure for storing `(key, value)` pairs). In the following [Formal Data Structure Details](#formal-data-structure-details) section, we detail the design and mechanics of the B-field using mathematical notation (i.e., we discuss it as an associate array mapping a set of_ $(x, y)$ _pairs). The [generated Rust documentation](https://docs.rs/bfield/latest/bfield/) includes both notations for ease of reference._
 
 ## Implementation Details
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ for p in 0..4u32 {
 
 * After creation, a B-field can optionally be loaded from a directory containing the produced `mmap` and related files with the `load` function. And once created or loaded, a B-field can be directly queried using the `get` function, which will either return `None`, `Indeterminate`, or `Some(BFieldValue)` (which is currently an alias for `Some(u32)` see [limitations](#⚠️-current-limitations-of-the-rust-bfield-implementation) below for more details):
 
-```rust
+```rust no_run
 use bfield::BField;
 
 // Load based on filename of the first array ".0.bfd"

--- a/src/bfield.rs
+++ b/src/bfield.rs
@@ -312,6 +312,7 @@ mod tests {
     }
 }
 
+// Causes cargo test to run doc tests on all `rust` code blocks
 #[doc = include_str!("../README.md")]
 #[cfg(doctest)]
-pub struct ReadmeDoctests;
+struct ReadmeDoctests;

--- a/src/combinatorial.rs
+++ b/src/combinatorial.rs
@@ -63,9 +63,9 @@ pub fn unrank(marker: u128) -> usize {
     value as usize
 }
 
-/// (Hopefully) fast implementation of a binomial
+/// (Hopefully) fast implementation of a binomial.
 ///
-/// This uses a preset group of equations for k < 8 and then falls back to a
+/// This function uses a preset group of equations for k < 8 and then falls back to a
 /// multiplicative implementation that tries to prevent overflows while
 /// maintaining all results as exact integers.
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,15 @@
 #![deny(missing_docs)]
 
-//! The bfield datastructure, implemented in Rust.
+//! The B-field datastructure, implemented in Rust.
 //! A space-efficient, probabilistic data structure and storage and retrieval method for key-value information.
+//! These Rust docs represent some minimal documentation of the crate itself.
+//! See the [Github README](https://github.com/onecodex/rust-bfield) for an
+//! extensive write-up, including the math and design underpinning the B-field
+//! data structure, guidance on B-field parameter selection, as well as usage
+//! examples.[^1]
+//!
+//! [^1]: These are not embeddable in the Cargo docs as they include MathJax,
+//! which is currently unsupported.
 
 mod bfield;
 mod bfield_member;


### PR DESCRIPTION
There's currently an issue with `mmap-bitvec` pointer dereferencing for 1.70+, which seems to relate to this change in `rust` 1.70:

> [Insert alignment checks for pointer dereferences as debug assertions](https://github.com/rust-lang/rust/pull/98112) This catches undefined behavior at runtime, and may cause existing code to fail.

(And here's [another related issue](https://github.com/wasmerio/wasmer/issues/4072)). We'll need to:

- [x] Fix this in `mmap-bitvec`
- [x] Add a regression test (tests there pass just fine...)
- [x] Release a new `mmap-bitvec`
- [x] Update the dependency here

@GSGerritsen I know you're out, but FYI I may have to ping you to add me on Cargo in order to publish a new version of `mmap-bitvec` because I believe you're the only one with keys (maybe @Keats  you have those too?).